### PR TITLE
Add apswutils as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -114,3 +114,6 @@
 [submodule "nb2fasthtml"]
 	path = nb2fasthtml
 	url = git@github.com:AnswerDotAI/nb2fasthtml.git
+[submodule "apswutils"]
+	path = apswutils
+	url = git@github.com:AnswerDotAI/apswutils.git


### PR DESCRIPTION
This adds apswutils to subs_aai, to make it easier to integrate our work with the rest of solveit, fastlite, etc. and verify that all works in repos using it. 

@pydanny has his own different non subs_aai way because he uses uv, so he will test without this.